### PR TITLE
camera-preview-stretched-and-videobitrate-from-2000k-to-700k

### DIFF
--- a/cineio-broadcast-android-sdk/src/main/java/com/arenacloud/broadcast/android/BroadcastView.java
+++ b/cineio-broadcast-android-sdk/src/main/java/com/arenacloud/broadcast/android/BroadcastView.java
@@ -121,7 +121,7 @@ public class BroadcastView extends GLSurfaceView implements SurfaceTexture.OnFra
             } catch (IOException ioe) {
                 throw new RuntimeException(ioe);
             }
-            mCamera.startPreview();
+            //mCamera.startPreview();
         }
 
         handleSetCameraOrientation();
@@ -525,7 +525,7 @@ public class BroadcastView extends GLSurfaceView implements SurfaceTexture.OnFra
                     break;
                 case MSG_SET_SURFACE_TEXTURE:
                     view.handleSetSurfaceTexture((SurfaceTexture) inputMessage.obj);
-                    view.handleResumeRecording();
+                    //view.handleResumeRecording();
                     break;
                 case MSG_CAPTURE_FRAME:
                     view.handleSaveFrameMessage(inputMessage);
@@ -561,7 +561,7 @@ public class BroadcastView extends GLSurfaceView implements SurfaceTexture.OnFra
 
 //        parms.setPreviewSize(1280, 720);
 
-//        mCamera.setParameters(parms);
+        mCamera.setParameters(parms);
 
         this.queueEvent(new Runnable() {
             @Override
@@ -572,6 +572,7 @@ public class BroadcastView extends GLSurfaceView implements SurfaceTexture.OnFra
         });
 
         mCamera.setDisplayOrientation(result);
+        mCamera.startPreview();
     }
 
     private void setEncoderOrientation() {
@@ -629,7 +630,7 @@ public class BroadcastView extends GLSurfaceView implements SurfaceTexture.OnFra
             throw new RuntimeException(ioe);
         }
 
-        mCamera.startPreview();
+        //mCamera.startPreview();
 
         weakSurfaceTexture = new WeakReference<SurfaceTexture>(st);
     }

--- a/cineio-broadcast-android-sdk/src/main/java/com/arenacloud/broadcast/android/streaming/EncodingConfig.java
+++ b/cineio-broadcast-android-sdk/src/main/java/com/arenacloud/broadcast/android/streaming/EncodingConfig.java
@@ -30,7 +30,7 @@ public class EncodingConfig {
     private static final int LANDSCAPE_CAMERA_WIDTH = 1280;
     private int customHeight;
     private static final int LANDSCAPE_CAMERA_HEIGHT = 720;
-    private static int DEFAULT_BIT_RATE = 2000000/*1500000*//*750000*/;
+    private static int DEFAULT_BIT_RATE = 700000/*1500000*//*750000*/;
     public static int DEFAULT_HUMAN_FPS = 15;
     private EncodingCallback mEncodingCallback;
     private MUXER_STATE mMuxerState;


### PR DESCRIPTION
1、fix camera preview stretched problem
2、change video bitrate from 2000k to 700k